### PR TITLE
Adds an insecure network security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,37 @@ resource "azurerm_network_security_group" "insecure_nsg" {
   }
 }
 
+resource "azurerm_virtual_machine" "insecure_vm" {
+  name                  = "insecure-vm"
+  location              = "West Europe"
+  resource_group_name   = "example-resources"
+  network_interface_ids = ["fake-nic-id"]
+  vm_size               = "Standard_DS1_v2"
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "osdisk"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "hostname"
+    admin_username = "adminuser"
+    admin_password = "Password1234!"  # Hardcoded password is a security issue
+  }
+  
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}
 
 # end
 #--------------------------------------------*--------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,24 @@ resource "azurerm_storage_account" "insecure_storage" {
   # Missing encryption settings
 }
 
+resource "azurerm_network_security_group" "insecure_nsg" {
+  name                = "insecure-nsg"
+  location            = "West Europe"
+  resource_group_name = "example-resources"
+
+  security_rule {
+    name                       = "allow-all"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
 
 # end
 #--------------------------------------------*--------------------------------------------


### PR DESCRIPTION
Adds a network security group configured to allow all inbound traffic, for demonstration purposes of insecure configurations.

Fixes #(issue) .

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

-
-
-
@cdornele